### PR TITLE
Fix the null MissionControl object in the VisionWidgetModel

### DIFF
--- a/android-uxsdk-beta/src/main/java/dji/ux/beta/widget/vision/VisionWidget.java
+++ b/android-uxsdk-beta/src/main/java/dji/ux/beta/widget/vision/VisionWidget.java
@@ -37,7 +37,6 @@ import dji.ux.beta.base.uxsdkkeys.ObservableInMemoryKeyedStore;
 import java.util.HashMap;
 import java.util.Map;
 
-import dji.sdk.sdkmanager.DJISDKManager;
 import dji.thirdparty.io.reactivex.android.schedulers.AndroidSchedulers;
 import dji.ux.beta.R;
 import dji.ux.beta.base.DJISDKModel;
@@ -83,8 +82,7 @@ public class VisionWidget extends FrameLayoutWidget {
 
         if (!isInEditMode()) {
             widgetModel = new VisionWidgetModel(DJISDKModel.getInstance(),
-                                                ObservableInMemoryKeyedStore.getInstance(),
-                                                DJISDKManager.getInstance().getMissionControl());
+                                                ObservableInMemoryKeyedStore.getInstance());
         }
 
         initDefaultIcons();


### PR DESCRIPTION
### Summary:
~~~
The MissionControl object in the VisionWidgetModel was always null because it was initialized before the DJI SDK was registered. This fixes the VisionWidgetModel so it always fetches the latest MissionControl object from the DJISDKManager.
~~~
### Manually tested with no issues on the following products:
~~~
Phantom 4 Pro
~~~
### Link to the relevant Github issue:
~~~
N/A
~~~
### Screenshots
~~~
N/A
~~~