### PR TITLE
Fix wrong FPV video aspect ratio

### DIFF
--- a/android-uxsdk-beta-core/src/main/java/dji/ux/beta/core/widget/fpv/FPVWidget.java
+++ b/android-uxsdk-beta-core/src/main/java/dji/ux/beta/core/widget/fpv/FPVWidget.java
@@ -289,8 +289,8 @@ public class FPVWidget extends ConstraintLayoutWidget implements TextureView.Sur
      */
     private void changeView(int width, int height, int relativeWidth, int relativeHeight) {
         ViewGroup.LayoutParams lp = fpvTextureView.getLayoutParams();
-        lp.width = width;
-        lp.height = height;
+        lp.width = relativeWidth;
+        lp.height = relativeHeight;
         fpvTextureView.setLayoutParams(lp);
         if (width > viewWidth) {
             fpvTextureView.setScaleX((float) width / viewWidth);


### PR DESCRIPTION
If the videoType like "Ratio4X3_IN16X9", the width and height from changeView will become 16:9, but the real ratio is 4:3 (in relativeWidth and relativeHeight). So the video in FPVWidget will be stretched.