### PR TITLE
Fix FlyZoneHelper.addCircleToMap's NullPointerException

### DIFF
--- a/android-uxsdk-beta-map/src/main/java/dji/ux/beta/map/widget/map/FlyZoneHelper.java
+++ b/android-uxsdk-beta-map/src/main/java/dji/ux/beta/map/widget/map/FlyZoneHelper.java
@@ -618,6 +618,9 @@ public class FlyZoneHelper {
     }
 
     private void addCircleToMap(FlyZoneInformation zone, DJICircle circle, String zoneId) {
+        if (zone == null || circle == null || zoneId == null) {
+            return;
+        }
         switch (zone.getCategory()) {
             case RESTRICTED:
                 restrictedDJICircleMap.put(zoneId, circle);


### PR DESCRIPTION
Fatal Exception: java.lang.NullPointerException
at java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1019)
at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1014)
at dji.ux.beta.map.widget.map.FlyZoneHelper.addCircleToMap(FlyZoneHelper.java:632)
at dji.ux.beta.map.widget.map.FlyZoneHelper.drawFlyZone(FlyZoneHelper.java:511)
at dji.ux.beta.map.widget.map.FlyZoneHelper.onFlyZoneListUpdate(FlyZoneHelper.java:204)
at dji.ux.beta.map.widget.map.MapWidget.onFlyZoneListUpdate(MapWidget.java:653)
at dji.ux.beta.map.widget.map.MapWidget.lambda$CC8HqsDVt_Ue_wJysFAlWmsF6h8()
at dji.ux.beta.map.widget.map.-$$Lambda$MapWidget$CC8HqsDVt_Ue_wJysFAlWmsF6h8.accept(:4)
at dji.thirdparty.io.reactivex.internal.observers.ConsumerSingleObserver.onSuccess(:2)
at dji.thirdparty.io.reactivex.internal.operators.single.SingleObserveOn$ObserveOnSingleObserver.run(:14)
at dji.thirdparty.io.reactivex.android.schedulers.HandlerScheduler$ScheduledRunnable.run(:2)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:246)
at android.app.ActivityThread.main(ActivityThread.java:8633)
at java.lang.reflect.Method.invoke(Method.java)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)