### PR TITLE
Fix build.gradle for Android Studio (Build #AI-212.5712.43.2112.8512…

### DIFF
--- a/android-uxsdk-beta-sample/build.gradle
+++ b/android-uxsdk-beta-sample/build.gradle
@@ -30,7 +30,6 @@ android {
         abortOnError = false
     }
     compileSdkVersion 31
-    buildToolsVersion "31.0.0"
     useLibrary 'org.apache.http.legacy'
     defaultConfig {
         applicationId "com.dji.ux.beta.sample"


### PR DESCRIPTION
The new Android Studio manages the default SDK tools version based on the value of compileSdkVersion.  You need to remove the buildToolsVersion attribute or sync will fail.